### PR TITLE
Update main buttons to fix edge click cases

### DIFF
--- a/src/components/AccountDetails/Copy.tsx
+++ b/src/components/AccountDetails/Copy.tsx
@@ -1,11 +1,42 @@
 import React from "react";
 import styled from "styled-components";
 import useCopyClipboard from "../../hooks/useCopyClipboard";
-
-import { CheckCircle, Copy } from "react-feather";
+import { CheckCircle, Copy as CopyIcon } from "react-feather";
 import { LinkStyledButton } from "../../theme";
 
-const CopyIcon = styled(LinkStyledButton)`
+const RoundedLink = styled(LinkStyledButton)<{ numOfLinks?: number }>`
+  font-size: 15px;
+  max-height: 65px;
+  padding: 15px;
+  background-color: #ff3700;
+  border-radius: 12px;
+  border: solid #ff3700;
+  border-width: 1px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all 0.2s;
+  min-width: ${({ numOfLinks }) => (numOfLinks === 2 ? "342px" : "100%")};
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    width: 100%;
+    gap: 10px;
+    margin-bottom: 10px;
+  `};
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    min-width: fit-content;
+  `}
+  a {
+    text-decoration: none;
+  }
+  :hover {
+    background-color: #ffbc7d;
+  }
+  :active {
+    transform: scale(0.95) translateY(4px);
+  }
+`;
+
+const CopyButton = styled(RoundedLink)`
   color: ${({ theme }) => theme.white};
   min-height: 46px;
   flex-shrink: 0;
@@ -13,8 +44,7 @@ const CopyIcon = styled(LinkStyledButton)`
   align-items: center;
   text-decoration: none;
   font-size: 15px;
-  transition: color 0.2s;
-  transition: fill 0.2s;
+  transition: all 0.2s !important;
   :focus {
     text-decoration: none;
   }
@@ -24,6 +54,35 @@ const CopyIcon = styled(LinkStyledButton)`
   :hover {
     color: #ff3700;
     text-decoration: none;
+  }
+  text-decoration: none;
+  span span svg {
+    fill: #ff3700;
+  }
+`;
+
+const Copy = styled(LinkStyledButton)<{
+  minWidth?: string;
+  minHeight?: string;
+}>`
+  color: #ff3700;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  font-size: 15px;
+  min-width: ${({ minWidth }) => (minWidth ? minWidth : "fit-content")};
+  min-height: ${({ minHeight }) => (minHeight ? minHeight : "unset")};
+  justify-content: center;
+  align-items: center;
+  :focus {
+    text-decoration: none;
+  }
+  :active {
+    text-decoration: none;
+  }
+  :hover {
+    text-decoration: none;
+    color: #ffbc7d;
   }
   text-decoration: none;
   span span svg {
@@ -45,14 +104,21 @@ const TransactionStatusText = styled.span`
   align-items: center;
 `;
 
+// this is copy buttons which are already implemented (mainly for copying eth address on DelegateInfo, AccountDetails and PayoutInfo)
 const CopyHelper = (props: {
   toCopy: string;
+  minWidth?: string;
+  minHeight?: string;
   children?: React.ReactNode;
 }): JSX.Element => {
   const [isCopied, setCopied] = useCopyClipboard();
 
   return (
-    <CopyIcon onClick={() => setCopied(props.toCopy)}>
+    <Copy
+      onClick={() => setCopied(props.toCopy)}
+      minWidth={props.minWidth}
+      minHeight={props.minHeight}
+    >
       {isCopied ? (
         <TransactionStatusText>
           <CheckCircle size={"20"} />
@@ -61,12 +127,42 @@ const CopyHelper = (props: {
       ) : (
         <TransactionStatusText>
           <CopyIconWrapper>
-            <Copy size={"20"} />
+            <CopyIcon size={"20"} />
           </CopyIconWrapper>
         </TransactionStatusText>
       )}
       {isCopied ? "" : props.children}
-    </CopyIcon>
+    </Copy>
+  );
+};
+
+// this is for main copy link button on Campaign page
+export const CopyBtn = (props: {
+  toCopy: string;
+  numOfLinks?: number | undefined;
+  children?: React.ReactNode;
+}): JSX.Element => {
+  const [isCopied, setCopied] = useCopyClipboard();
+
+  return (
+    <CopyButton
+      onClick={() => setCopied(props.toCopy)}
+      numOfLinks={props.numOfLinks}
+    >
+      {isCopied ? (
+        <TransactionStatusText>
+          <CheckCircle size={"20"} />
+          <TransactionStatusText>Copied</TransactionStatusText>
+        </TransactionStatusText>
+      ) : (
+        <TransactionStatusText>
+          <CopyIconWrapper>
+            <CopyIcon size={"20"} />
+          </CopyIconWrapper>
+        </TransactionStatusText>
+      )}
+      {isCopied ? "" : props.children}
+    </CopyButton>
   );
 };
 

--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -5,7 +5,7 @@ import { useActiveWeb3React } from "../../hooks";
 import { clearAllTransactions } from "../../state/transactions/actions";
 import { shortenAddress } from "../../utils";
 import { AutoRow } from "../Row";
-import Copy from "./Copy";
+import CopyHelper from "./Copy";
 import Transaction from "./Transaction";
 
 import { SUPPORTED_WALLETS } from "../../constants/wallet";
@@ -360,11 +360,15 @@ export default function AccountDetails({
                     <AccountControl>
                       <div>
                         {account && (
-                          <Copy toCopy={account}>
+                          <CopyHelper
+                            toCopy={account}
+                            minHeight='26px'
+                            minWidth='141px'
+                          >
                             <span style={{ marginLeft: "4px" }}>
                               Copy Address
                             </span>
-                          </Copy>
+                          </CopyHelper>
                         )}
                         {chainId && account && (
                           <AddressLink
@@ -389,11 +393,15 @@ export default function AccountDetails({
                     <AccountControl>
                       <div>
                         {account && (
-                          <Copy toCopy={account}>
+                          <CopyHelper
+                            toCopy={account}
+                            minHeight='26px'
+                            minWidth='141px'
+                          >
                             <span style={{ marginLeft: "4px" }}>
                               Copy Address
                             </span>
-                          </Copy>
+                          </CopyHelper>
                         )}
                         {chainId && account && (
                           <AddressLink

--- a/src/components/Menu/SideMenu.tsx
+++ b/src/components/Menu/SideMenu.tsx
@@ -53,6 +53,10 @@ const Wrapper = styled.div<{ open: boolean }>`
       border-radius: 10px;
       background-color: #c0c1c1;
     }
+
+    ::-webkit-scrollbar-thumb:hover {
+      cursor: default;
+    }
   }
 `;
 

--- a/src/components/ReferralLinksCard/index.tsx
+++ b/src/components/ReferralLinksCard/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import Copy from "components/AccountDetails/Copy";
+import { CopyBtn } from "components/AccountDetails/Copy";
 import { useActiveWeb3React } from "hooks";
 import { useActiveCampaign, useReferralLink } from "state/campaigns/hooks";
 import { useVerifiedHandle } from "state/social/hooks";
@@ -24,39 +24,6 @@ export const Break = styled.div`
   background-color: ${({ theme }) => theme.bg3};
   height: 1px;
   margin: 0;
-`;
-
-const RoundedLink = styled.div<{ numOfLinks?: number }>`
-  font-size: 15px;
-  max-height: 65px;
-  padding: 15px;
-  background-color: #ff3700;
-  border-radius: 12px;
-  border: solid #ff3700;
-  border-width: 1px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  transition: background-color 0.2s;
-  transition: all 0.4s;
-  min-width: ${({ numOfLinks }) => (numOfLinks === 2 ? "342px" : "100%")};
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    width: 100%;
-    gap: 10px;
-    margin-bottom: 10px;
-  `};
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    min-width: fit-content;
-  `}
-  a {
-    text-decoration: none;
-  }
-  :hover {
-    background-color: #ffbc7d;
-  }
-  :active {
-    transform: scale(0.9) translateY(8px);
-  }
 `;
 
 const RoundedLinkLoggedOut = styled.div<{ numOfLinks?: number }>`
@@ -104,18 +71,18 @@ export const ReferralCardLink = styled.a`
   }
 `;
 
-const RoundedLinkTweetintent = styled.div`
+const RoundedLinkTweetintent = styled.a`
   font-size: 15px;
   background-color: #ff3700;
   max-height: 65px;
+  text-decoration: none;
   border-radius: 12px;
   border: solid #ff3700;
   border-width: 1px;
   display: flex;
   justify-content: space-around;
   align-items: center;
-  transition: background-color 0.2s;
-  transition: all 0.4s;
+  transition: all 0.2s;
   ${({ theme }) => theme.mediaWidth.upToSmall`
   width: 100%;
 `};
@@ -124,7 +91,7 @@ const RoundedLinkTweetintent = styled.div`
     background-color: #ffbc7d;
   }
   :active {
-    transform: scale(0.9) translateY(8px);
+    transform: scale(0.95) translateY(4px);
   }
 `;
 
@@ -156,31 +123,30 @@ export default function ReferralLinksCard() {
                 gap: "10px",
               }}
             >
-              <RoundedLink numOfLinks={twitterIntentUrl ? 2 : 1}>
-                <Copy toCopy={"https://" + referralLink}>
-                  <div style={{ padding: "5px" }}>
-                    <div>
-                      {"  "}
-                      Copy your unique link &amp; start earning
-                      {/* {utmLinks[activeProtocol?.id]} */}
-                    </div>
-                    {activeCampaign && (
-                      <div style={{ fontSize: "9px", padding: "2px" }}>
-                        {activeCampaign.baseUrl.replace("?", "")}
-                      </div>
-                    )}
+              <CopyBtn
+                toCopy={"https://" + referralLink}
+                numOfLinks={twitterIntentUrl ? 2 : 1}
+              >
+                <div style={{ padding: "5px" }}>
+                  <div>
+                    {"  "}
+                    Copy your unique link &amp; start earning
+                    {/* {utmLinks[activeProtocol?.id]} */}
                   </div>
-                </Copy>
-              </RoundedLink>
+                  {activeCampaign && (
+                    <div style={{ fontSize: "9px", padding: "2px" }}>
+                      {activeCampaign.baseUrl.replace("?", "")}
+                    </div>
+                  )}
+                </div>
+              </CopyBtn>
               {twitterIntentUrl && (
                 <RoundedLinkTweetintent
                   style={{ padding: "20px" }}
+                  href={twitterIntentUrl}
                   // numOfLinks={twitterIntentUrl ? 2 : 1}
                 >
-                  <ReferralCardLink
-                    style={{ textDecoration: "none" }}
-                    href={twitterIntentUrl}
-                  >
+                  <ReferralCardLink style={{ textDecoration: "none" }}>
                     <div style={{ display: "flex", alignItems: "center" }}>
                       <div style={{ flex: "0 1 auto" }}>
                         Tweet your unique link

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -71,6 +71,23 @@ const ContentWrapper = styled.div`
     padding-top: 1rem;
     padding-bottom: 120px;
   }
+
+  ::-webkit-scrollbar {
+    height: 5px;
+    width: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    -webkit-border-radius: 10px;
+    border-radius: 10px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    opacity: 0.1;
+    -webkit-border-radius: 10px;
+    border-radius: 10px;
+    background-color: #c0c1c1;
+  }
 `;
 
 function TopLevelModals() {

--- a/src/pages/DelegateInfo.tsx
+++ b/src/pages/DelegateInfo.tsx
@@ -254,7 +254,7 @@ function DelegateInfo({
                       </TYPE.black>
                     </ExternalLink>
                     {!twitterHandle && !delegateInfo?.autonomous && (
-                      <CopyHelper toCopy={formattedAddress} />
+                      <CopyHelper toCopy={formattedAddress} minHeight='26px' />
                     )}
                   </RowFixed>
                   {twitterHandle ||
@@ -272,7 +272,7 @@ function DelegateInfo({
                           {shortenAddress(delegateAddress)}
                         </TYPE.black>
                       </ExternalLink>
-                      <CopyHelper toCopy={formattedAddress} />
+                      <CopyHelper toCopy={formattedAddress} minHeight='26px' />
                     </RowFixed>
                   ) : (
                     <TYPE.black fontSize='12px'>


### PR DESCRIPTION
Redesigned the implementation of main buttons and added some customs attributes to CopyHelper component.
Refactored Copy.tsx just a little to not get confused between CopyIcon, CopyButton, CopyHelper. Main Copy button has its own component CopyBtn now.
Twitter button all the same just made the parent to be a link as well and added the 'href' attribute to it instead of to the element "inside" the button.
minWidth and minHeight changes to CopyHelper references for layout consistency.